### PR TITLE
Adding Discord Link to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ If you're interested in working on any of these issues, please let us know by su
   
 </p>
 
+### Join our Discord Server:
+
+<p>
+  
+We have a Discord server for contributors to the Stoccoin's website on GitHub. Join our community of developers, designers, marketers, and other contributors to share your skills, collaborate on code, provide feedback, and contribute to the Stoccoin's project in meaningful ways.
+
+[Click here to join our Discord server](https://discord.gg/XVE7eaS9AA)
+  
+</p>
+
 ## License
 
 This project is licensed under the Affero General Public License v3.0. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Hello, this is my first time contributing, and I noticed the issue here:
https://github.com/Stoccoin-Official/Stoccoin-Website/issues/36, which involved adding the Discord Link to the main readme in the repo. I have attempted to do so. Any feedback would be gratefully appreciated.