### PR TITLE
fix: Start server from only one file

### DIFF
--- a/server/App.js
+++ b/server/App.js
@@ -38,10 +38,4 @@ app.use(function(err, req, res, next) {
   res.render('error');
 });
 
-// start the server
-var port = 3000;
-app.listen(port, function () {
-  console.log('Server running on port ' + port);
-});
-
 module.exports = app;

--- a/server/bin/www
+++ b/server/bin/www
@@ -87,4 +87,5 @@ function onListening() {
     ? 'pipe ' + addr
     : 'port ' + addr.port;
   debug('Listening on ' + bind);
+  console.log('Listening on ' + bind);
 }


### PR DESCRIPTION
@royalpinto007 
Previously, the server was starting from two separate files (`\server\bin\www` and `\server\App.js`), leading to the `Port 3000 is already in use` error. To address this issue, I have removed the server listen functionality from `\server\App.js`.

As a contributor for GSSoC '23, I kindly request the repository maintainers to review and merge the pull request. Your attention and assistance in resolving this matter are greatly appreciated.

Thank you.