### PR TITLE
docs: fixed table of contents in crypto-market-basics file

### DIFF
--- a/Education/crypto-market-basics.md
+++ b/Education/crypto-market-basics.md
@@ -1,52 +1,62 @@
-CRYPTO MARKET BASICS
+# Table of contents
 
-Introduction
+- [Table of contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [1. Cryptocurrency?](#1-cryptocurrency)
+  - [2. Blockchain Technology](#2-blockchain-technology)
+  - [3. Decentralization](#3-decentralization)
+  - [4. Cryptocurrency Exchanges](#4-cryptocurrency-exchanges)
+  - [5. Wallets and Security](#5-wallets-and-security)
+  - [6. Market Volatility](#6-market-volatility)
+  - [7. Crypto Trading Strategies](#7-crypto-trading-strategies)
+  - [8. Initial Coin Offerings (ICOs)](#8-initial-coin-offerings-icos)
+  - [9. Regulatory Environment](#9-regulatory-environment)
+
+## Introduction
+
 Welcome to the world of cryptocurrency! This document aims to provide you with a basic understanding of the crypto market and its key concepts. Whether you're new to the field or looking to refresh your knowledge, this guide will cover the fundamental aspects of the crypto market.
 
-TABLE OF CONTENTS
-1. What is Cryptocurrency?
-2. Blockchain Technology
-3. Decentralization
-4. Cryptocurrency Exchanges
-5. Wallets and Security
-6. Market Volatility
-7. Crypto Trading Strategies
-8. Initial Coin Offerings (ICOs)
-9. Regulatory Environment
-10. Future of the Crypto Market
+## 1. Cryptocurrency?
 
-1. What is Cryptocurrency?
 Cryptocurrency is a digital or virtual form of currency that uses cryptography for security.
 Unlike traditional fiat currencies issued by central banks, cryptocurrencies operate independently of any central authority. The most well-known cryptocurrency is Bitcoin, but there are thousands of other cryptocurrencies available today, each with its own unique features and purposes.
 
-2. Blockchain Technology
+## 2. Blockchain Technology
+
 Blockchain technology is the underlying foundation of most cryptocurrencies.
 It is a decentralized and distributed ledger that records transactions across multiple computers or nodes. Each transaction is grouped into a block and added to a chain of previous blocks, creating an immutable record of all transactions. This technology ensures transparency, security, and eliminates the need for intermediaries in financial transactions.
 
-3. Decentralization
+## 3. Decentralization
+
 Decentralization is a key characteristic of cryptocurrencies.
 Unlike traditional banking systems where a central authority controls transactions, cryptocurrencies operate on a peer-to-peer network. This means that transactions occur directly between users, without the need for intermediaries. Decentralization enhances security, privacy, and removes single points of failure.
 
-4. Cryptocurrency Exchanges
+## 4. Cryptocurrency Exchanges
+
 Cryptocurrency exchanges are platforms where users can buy, sell, and trade cryptocurrencies.
 These exchanges act as intermediaries, facilitating the conversion between cryptocurrencies and fiat currencies. It's important to choose a reputable and secure exchange, as the security of your funds relies on the exchange's infrastructure.
 
-5. Wallets and Security
+## 5. Wallets and Security
+
 Cryptocurrency wallets are digital tools used to store, send, and receive cryptocurrencies.
 There are two main types of wallets: hot wallets and cold wallets. Hot wallets are connected to the internet and are convenient for frequent transactions, while cold wallets are offline and offer enhanced security for long-term storage. It's crucial to keep your wallet secure by using strong passwords, enabling two-factor authentication, and regularly updating your software.
 
-6. Market Volatility
+## 6. Market Volatility
+
 The crypto market is known for its high volatility, with prices experiencing significant fluctuations over short periods.
 Cryptocurrency prices are influenced by various factors, including market demand, regulatory developments, technological advancements, and investor sentiment. It's important to be aware of the risks associated with volatility and make informed decisions when participating in the market.
 
-7. Crypto Trading Strategies
+## 7. Crypto Trading Strategies
+
 Crypto trading involves buying and selling cryptocurrencies to take advantage of price movements.
 Various trading strategies, such as day trading, swing trading, and long-term investing, can be employed based on individual preferences and risk tolerance. It's crucial to conduct thorough research, analyze market trends, and develop a sound trading strategy to increase the chances of success.
 
-8. Initial Coin Offerings (ICOs)
+## 8. Initial Coin Offerings (ICOs)
+
 Initial Coin Offerings (ICOs) are fundraising events in which new cryptocurrencies or tokens are sold to investors.
 ICOs allow project teams to raise capital for their ventures, and investors to participate in potentially lucrative opportunities. However, ICOs can be risky, as some projects may fail to deliver on their promises. Conducting due diligence and evaluating the credibility of the project is essential before investing in an ICO.
 
-9. Regulatory Environment
+## 9. Regulatory Environment
+
 The regulatory landscape surrounding cryptocurrencies varies across different countries and jurisdictions.
 Governments and regulatory bodies are actively developing


### PR DESCRIPTION
Fixes #273 

## Description
- Numbering in `crypto-market-basics.md` file is made proper.
- The links to individual section are now working as expected in table of contents.

## Before
![issue_stoccion_crypto](https://github.com/Stoccoin-Official/Stoccoin-Website/assets/116940083/05bb00c7-3596-42a8-a88e-2f8aa04fd2c1)


## After

https://github.com/Stoccoin-Official/Stoccoin-Website/assets/116940083/1b4556f7-d749-4995-9aab-91076f8477e3

