### PR TITLE
feat : Add custom error page (404)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,6 +10,7 @@ import Trade from "./pages/Trade";
 import Institutional from "./pages/Institutional";
 import Derivatives from "./pages/Derivatives";
 import Support from "./pages/Support";
+import NotFound from "./components/NotFound.jsx";
 const App = () => {
   return (
     <div className="App">
@@ -25,6 +26,7 @@ const App = () => {
           <Route path="/Institutional" element={<Institutional />} />
           <Route path="/Derivatives" element={<Derivatives />} />
           <Route path="/Support" element={<Support />} />
+          <Route path="*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>
     </div>

--- a/client/src/components/NotFound.jsx
+++ b/client/src/components/NotFound.jsx
@@ -1,0 +1,17 @@
+import { Link } from "react-router-dom";
+
+const NotFound = () => {
+  return (
+    <div className="flex flex-col items-center justify-center h-screen bg-gray-100">
+      <h1 className="text-4xl font-bold text-gray-800">404 - Page Not Found</h1>
+      <p className="text-lg text-gray-600 mt-4">
+        The requested page does not exist.
+      </p>
+      <Link to="/" className="mt-6 text-blue-500 hover:underline">
+        Go back to homepage
+      </Link>
+    </div>
+  );
+};
+
+export default NotFound;


### PR DESCRIPTION
## What does this PR do?

This PR adds a custom error page (404) to the project. It addresses issue #111  by providing a dedicated page for handling cases when a requested page is not found. The custom error page displays a clear error message and includes a link to return to the homepage, improving the user experience.

Fixes #111 

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->

## Type of change

- New feature (non-breaking change which adds functionality)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Navigate to a non-existent page or URL.
- [ ] Verify that the custom error page (404) is displayed.
- [ ] Check that the error message is visible and clearly states the page is not found.
- [ ] Click on the provided link to return to the homepage and verify that it redirects properly.



