### PR TITLE
feat: Dark mode for desktop

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Stoccoin</title>
   </head>
-  <body>
+  <body className="dark">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -1,8 +1,7 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+* {
+  box-sizing: border-box;
+  padding: 0%;
+  margin: 0%;
 }
 
 .logo {

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -48,11 +48,11 @@ const App = () => {
               <Routes>
                 <Route path="/" element={<Homepage />} />
                 <Route path="/Dashboard" element={<Dashboard />} />
-                <Route path="/Stocks" element={<Stocks />} />
+                <Route path="/Stocks" element={<Stocks darkMode={darkMode} />} />
                 <Route path="/Cryptocurrencies" element={<Cryptocurrencies darkMode={darkMode} />} />
-                <Route path="/News" element={<News />} />
+                <Route path="/News" element={<News darkMode={darkMode} />} />
                 <Route path="/NFT" element={<NFT />} />
-                <Route path="/Trade" element={<Trade />} />
+                <Route path="/Trade" element={<Trade darkMode={darkMode} />} />
                 <Route path="/Institutional" element={<Institutional />} />
                 <Route path="/Derivatives" element={<Derivatives />} />
                 <Route path="/Support" element={<Support />} />

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -21,6 +21,7 @@ import { auth } from "./firebase/auth";
 
 const App = () => {
   const [user, setUser] = useState(null);
+  const [darkMode, setDarkMode] = useState(false);
 
   useEffect(() => {
     const authorizeUser = auth.onAuthStateChanged((authUser) => {
@@ -40,25 +41,29 @@ const App = () => {
   return (
     <div className="App">
       <BrowserRouter>
-        <Navbar />
-        <Suspense fallback={<FaCircleNotch className="spinner" size="5em" />}>
-          <Routes>
-            <Route path="/" element={<Homepage />} />
-            <Route path="/Dashboard" element={<Dashboard />} />
-            <Route path="/Stocks" element={<Stocks />} />
-            <Route path="/Cryptocurrencies" element={<Cryptocurrencies />} />
-            <Route path="/News" element={<News />} />
-            <Route path="/NFT" element={<NFT />} />
-            <Route path="/Trade" element={<Trade />} />
-            <Route path="/Institutional" element={<Institutional />} />
-            <Route path="/Derivatives" element={<Derivatives />} />
-            <Route path="/Support" element={<Support />} />
-            <Route path="/SignUp" element={<SignUp />} />
-            <Route path="/Login" element={<Login />} />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </Suspense>
-        <Footer />
+        <div className={darkMode ? "dark" : ""}>
+          <div className="dark:bg-slate-900">
+            <Navbar darkMode={darkMode} setDarkMode={setDarkMode} />
+            <Suspense fallback={<FaCircleNotch className="spinner" size="5em" />}>
+              <Routes>
+                <Route path="/" element={<Homepage />} />
+                <Route path="/Dashboard" element={<Dashboard />} />
+                <Route path="/Stocks" element={<Stocks />} />
+                <Route path="/Cryptocurrencies" element={<Cryptocurrencies darkMode={darkMode} />} />
+                <Route path="/News" element={<News />} />
+                <Route path="/NFT" element={<NFT />} />
+                <Route path="/Trade" element={<Trade />} />
+                <Route path="/Institutional" element={<Institutional />} />
+                <Route path="/Derivatives" element={<Derivatives />} />
+                <Route path="/Support" element={<Support />} />
+                <Route path="/SignUp" element={<SignUp />} />
+                <Route path="/Login" element={<Login />} />
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </Suspense>
+            <Footer />
+          </div>
+        </div>
       </BrowserRouter>
     </div>
   );

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -46,7 +46,7 @@ const App = () => {
             <Navbar darkMode={darkMode} setDarkMode={setDarkMode} />
             <Suspense fallback={<FaCircleNotch className="spinner" size="5em" />}>
               <Routes>
-                <Route path="/" element={<Homepage />} />
+                <Route path="/" element={<Homepage darkMode={darkMode} />} />
                 <Route path="/Dashboard" element={<Dashboard />} />
                 <Route path="/Stocks" element={<Stocks darkMode={darkMode} />} />
                 <Route path="/Cryptocurrencies" element={<Cryptocurrencies darkMode={darkMode} />} />

--- a/app/src/components/Accordion.jsx
+++ b/app/src/components/Accordion.jsx
@@ -33,13 +33,13 @@ function Accordion() {
       <p className="mb-5 text-sm text-indigo-600 text-center font-semibold uppercase tracking-px">
         Have any questions?
       </p>
-      <h2 className="mb-8 text-4xl md:text-8xl xl:text-4xl text-center font-bold font-heading tracking-px-n leading-none">
+      <h2 className="mb-8 text-4xl md:text-8xl xl:text-4xl text-center font-bold font-heading tracking-px-n leading-none dark:text-white">
         Frequently Asked Questions
       </h2>
       <div className="mb-11 flex flex-wrap -m-1">
         {faq.map((member,index)=>(<QnA key={index} faq={member}/>))}
       </div>
-      <p className="text-gray-600 text-center font-medium">
+      <p className="text-gray-600 text-center font-medium dark:text-cyan-400">
         <span>Still have any questions? </span>
         <a
           className="font-semibold text-indigo-600 hover:text-indigo-700"
@@ -58,13 +58,13 @@ function QnA({faq}){
   return(
     <div className="w-full p-1">
           <div className='QnA' onClick={()=>setshow(!show)} >
-            <div className={`py-7 px-8 bg-white bg-opacity-60 border-2 rounded-2xl shadow-10xl ${show?' border-indigo-600':''}`}>
+            <div className={`py-7 px-8 bg-white dark:bg-slate-800 bg-opacity-60 border-2 rounded-2xl shadow-10xl ${show?' border-indigo-600':''}`}>
               <div className="flex flex-wrap justify-between -m-2">
                 <div className="flex-1 p-2">
-                  <h3 className=" text-lg font-semibold leading-normal">
+                  <h3 className="dark:text-cyan-100 text-lg font-semibold leading-normal">
                     {faq.que}
                   </h3>
-                  <p className={`text-gray-600 font-medium mt-4 ${show?'':'hidden'}` }>
+                  <p className={`text-gray-600 font-medium mt-4 dark:text-cyan-400 ${show?'':'hidden'}` }>
                     {faq.ans}
                   </p>
                 </div>

--- a/app/src/components/ContactForm.jsx
+++ b/app/src/components/ContactForm.jsx
@@ -26,7 +26,7 @@ export default function App() {
 
   return (
     <div
-      className="mx-auto grid max-w-screen-xl grid-cols-1 gap-8 rounded-lg bg-white-100 px-8 py-16 text-gray-900 md:grid-cols-2 md:px-12 lg:px-16 xl:px-32 pt-55 pb-20"
+      className="mx-auto grid max-w-screen-xl grid-cols-1 gap-8 rounded-lg bg-white-100 px-8 py-16 dark:text-white text-gray-900 md:grid-cols-2 md:px-12 lg:px-16 xl:px-32 pt-55 pb-20"
       id="contact"
     >
       <div className="flex flex-col justify-between">
@@ -34,7 +34,7 @@ export default function App() {
           <h2 className="text-4xl font-bold leading-tight lg:text-5xl">
             Get in Touch
           </h2>
-          <div className="mt-8 text-gray-700">
+          <div className="mt-8 text-gray-700 dark:text-cyan-300">
             Reach out to us with any questions or feedback you may have
           </div>
         </div>
@@ -45,32 +45,32 @@ export default function App() {
       <form onSubmit={handleSubmit}>
         <div className="">
           <div>
-            <span className="text-sm font-bold uppercase text-gray-600">
+            <span className="text-sm font-bold uppercase text-gray-600 dark:text-cyan-200">
               Full Name
             </span>
             <input
-              className="focus:shadow-outline mt-2 w-full rounded-lg bg-gray-300 p-3 text-gray-900 focus:outline-none"
+              className="dark:bg-slate-800 dark:text-cyan-300 focus:shadow-outline mt-2 w-full rounded-lg bg-gray-300 p-3 text-gray-900 focus:outline-none"
               type="text"
               placeholder=""
               onChange={(e) => setName(e.target.value)}
             />
           </div>
           <div className="mt-8">
-            <span className="text-sm font-bold uppercase text-gray-600">
+            <span className="text-sm font-bold uppercase text-gray-600 dark:text-cyan-200">
               Email
             </span>
             <input
-              className="focus:shadow-outline mt-2 w-full rounded-lg bg-gray-300 p-3 text-gray-900 focus:outline-none"
+              className="dark:bg-slate-800 dark:text-cyan-300 focus:shadow-outline mt-2 w-full rounded-lg bg-gray-300 p-3 text-gray-900 focus:outline-none"
               type="email"
               onChange={(e) => setEmail(e.target.value)}
             />
           </div>
           <div className="mt-8">
-            <span className="text-sm font-bold uppercase text-gray-600">
+            <span className="text-sm font-bold uppercase text-gray-600 dark:text-cyan-200">
               Message
             </span>
             <textarea
-              className="focus:shadow-outline mt-2 h-32 w-full rounded-lg bg-gray-300 p-3 text-gray-900 focus:outline-none"
+              className="dark:bg-slate-800 dark:text-cyan-300 focus:shadow-outline mt-2 h-32 w-full rounded-lg bg-gray-300 p-3 text-gray-900 focus:outline-none"
               defaultValue={""}
               onChange={(e) => setMessage(e.target.value)}
             />

--- a/app/src/components/Features.jsx
+++ b/app/src/components/Features.jsx
@@ -29,14 +29,14 @@ const features = [
 
 export default function Example() {
   return (
-    <div className="bg-white sm:py-14">
+    <div className="bg-white dark:bg-slate-900 sm:py-14">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl lg:text-center">
           <h2 className="text-base font-semibold leading-7 text-indigo-600">Trade Boosters</h2>
-            <h2 className="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+            <h2 className="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl dark:text-cyan-100">
               Streamlined Trading Features
             </h2> 
-          <p className="mt-6 text-lg leading-8 text-gray-600">
+          <p className="mt-6 text-lg leading-8 text-gray-600 dark:text-cyan-400">
             Explore the comprehensive list of features that make our trading platform stand out from the rest. Our powerful tools and advanced technologies are designed to enhance your trading experience and give you an edge in the market.
           </p>
         </div>
@@ -44,13 +44,13 @@ export default function Example() {
           <dl className="grid max-w-xl grid-cols-1 gap-y-10 gap-x-8 lg:max-w-none lg:grid-cols-2 lg:gap-y-16">
             {features.map((feature) => (
               <div key={feature.name} className="relative pl-16">
-                <dt className="text-base font-semibold leading-7 text-gray-900">
+                <dt className="text-base font-semibold leading-7 text-gray-900 dark:text-cyan-300">
                   <div className="absolute top-0 left-0 flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-600">
                     <feature.icon className="h-6 w-6 text-white" aria-hidden="true" />
                   </div>
                   {feature.name}
                 </dt>
-                <dd className="mt-2 text-base leading-7 text-gray-600">{feature.description}</dd>
+                <dd className="mt-2 text-base leading-7 text-gray-600 dark:text-cyan-600">{feature.description}</dd>
               </div>
             ))}
           </dl>

--- a/app/src/components/Footer.jsx
+++ b/app/src/components/Footer.jsx
@@ -21,7 +21,7 @@ function Footer() {
     });
   };
   return (
-    <footer className="bg-white">
+    <footer className="bg-white dark:bg-slate-900">
       <div className="container mx-auto px-4">
         <hr className="border-gray-700 my-8" />
         <div className="md:flex-row justify-center items-center flex md:justify-around flex-col p-2 md:items-start md:1/4">
@@ -35,14 +35,14 @@ function Footer() {
                 className="text-indigo-500 text-3xl mr-3 hover:transform hover:scale-110 transition duration-300 ease-in-out"
               />
             </Link>
-            <h1 className="text-6xl font-sans font-extrabold text-black mb-4 text-center">Stoccoin</h1>
-            <p className="font-semibold font-sans text-center md:text-start w-full md:w-96">
+            <h1 className="text-6xl font-sans font-extrabold text-black dark:text-cyan-100 mb-4 text-center">Stoccoin</h1>
+            <p className="font-semibold font-sans text-center md:text-start w-full md:w-96 dark:text-cyan-400">
               Discover our mission to provide real-time market data and curated news feeds for stocks and cryptocurrencies. <br /> Stay informed and make confident investment decisions with our comprehensive resources.
             </p>
           </div>
 
           <div className="flex md:flex-col md:mt-0 mt-4  md:1/4 justify-start text-left items-center gap-6 md:items-start">
-            <h2 className="text-3xl font-bold text-slate-800 mb-4">Follow Us</h2>
+            <h2 className="text-3xl font-bold text-slate-800 dark:text-cyan-100 mb-4">Follow Us</h2>
             <div className="list-none flex gap-6 md:grid grid-cols-2">
               <div className="mb-2">
                 <Link to="https://www.instagram.com/stoccoin/" target="_blank">
@@ -72,13 +72,14 @@ function Footer() {
               </div>
               <div className="mb-2">
                 <Link to="https://github.com/Stoccoin-Official/Stoccoin-Website" target="_blank">
-                  <BsGithub title="Github" size={30} className="fill-gray-700 hover:fill-[black] hover:transform hover:scale-125 transition-all duration-200 ease-in-out" />
+                  <BsGithub title="Github" size={30} className="fill-gray-700 hover:fill-[black] dark:hover:fill-white hover:transform hover:scale-125 transition-all duration-200 ease-in-out" />
                 </Link>
               </div>
             </div>
           </div>
+
           <div className="md:w-1/4 w-full px-3 mb-3 md:mb-0 text-left">
-            <h2 className="text-3xl font-bold text-slate-800 mb-4">Newsletter</h2>
+            <h2 className="text-3xl font-bold text-slate-800 mb-4 dark:text-cyan-100">Newsletter</h2>
             <form onSubmit={handleSubmit}>
               <div className="flex flex-col">
                 <AiFillMail className="relative top-[30px] ml-2 text-gray-700" size={20} />

--- a/app/src/components/Header.jsx
+++ b/app/src/components/Header.jsx
@@ -1,18 +1,18 @@
 export default function Header() {
   return (
-    <div className="bg-white">
+    <div className="bg-white dark:bg-slate-900">
       <div className="relative isolate px-6 pt-20 lg:px-8">
         <div className="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"></div>
         <div className="container mx-auto flex flex-wrap-reverse justify-center">
           <div className="md:w-1/2 max-w-xl w-full flex justify-center items-center my-1.5">
             <div className="md:text-left text-center">
               <h1
-                className="font-extrabold tracking-tight text-gray-900 text-7xl"
+                className="font-extrabold tracking-tight text-gray-900 text-7xl dark:text-cyan-100"
                 style={{ fontFamily: "'Open Sans Extra Bold', sans-serif" }}
               >
                 Stoccoin
               </h1>
-              <p className="mt-6 text-lg leading-8 text-gray-600">
+              <p className="mt-6 text-lg leading-8 text-gray-600 dark:text-cyan-400">
                 Learn-Invest-Repeat
               </p>
               <div className="mt-10 flex items-center md:justify-left gap-x-6 w-60 mx-auto md:mx-0">
@@ -24,7 +24,7 @@ export default function Header() {
                 </a>
                 <a
                   href="#"
-                  className="text-sm font-semibold leading-6 text-gray-900"
+                  className="text-sm font-semibold leading-6 text-gray-900 dark:text-cyan-50"
                 >
                   Learn more <span aria-hidden="true">→</span>
                 </a>

--- a/app/src/components/Navbar.jsx
+++ b/app/src/components/Navbar.jsx
@@ -4,6 +4,7 @@ import { Dialog } from "@headlessui/react";
 import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline";
 import { auth } from "../firebase/auth";
 import { signOut } from "firebase/auth";
+import { BsFillSunFill, BsFillMoonStarsFill } from "react-icons/bs";
 
 const navigation = [
   { name: "Dashboard", route: "/Dashboard" },
@@ -17,7 +18,7 @@ const navigation = [
   { name: "Support", route: "/Support" },
 ];
 
-export default function Example() {
+export default function Example({ darkMode, setDarkMode }) {
   let navigate = useNavigate();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
@@ -33,10 +34,10 @@ export default function Example() {
   };
 
   return (
-    <div className="bg-white">
+    <div className={darkMode ? "dark" : ""}>
       <header className="absolute inset-x-0 top-0 z-50">
         <nav
-          className="flex items-center justify-between p-6 lg:px-8"
+          className="flex items-center justify-between p-6 lg:px-8 bg-white dark:bg-slate-900"
           aria-label="Global"
         >
           <div className="flex lg:flex-1 ">
@@ -59,7 +60,7 @@ export default function Example() {
               onClick={() => setMobileMenuOpen(true)}
             >
               <span className="sr-only">Open main menu</span>
-              <Bars3Icon className="h-6 w-6" aria-hidden="true" />
+              <Bars3Icon className="dark:text-cyan-100 h-6 w-6" aria-hidden="true" />
             </button>
           </div>
           <div className="hidden lg:flex lg:gap-x-8">
@@ -67,7 +68,7 @@ export default function Example() {
               <NavLink to={item.route} key={item.name}>
                 <div
                   // href={item.href}
-                  className="nav text-sm font-semibold leading-6 text-gray-900 relative w-fit after:block after:content-[''] after:absolute after:h-[3px] after:bg-indigo-600 after:rounded-full after:w-full after:scale-x-0 after:hover:scale-x-100 after:transition after:duration-500 after:origin-center"
+                  className="nav text-sm font-semibold leading-6 text-gray-900 relative w-fit after:block after:content-[''] after:absolute after:h-[3px] after:bg-indigo-600 after:rounded-full after:w-full after:scale-x-0 after:hover:scale-x-100 after:transition after:duration-500 after:origin-center dark:text-cyan-100"
                 >
                   {item.name}
                 </div>
@@ -76,12 +77,24 @@ export default function Example() {
           </div>
           <div className="hidden lg:flex lg:flex-1 lg:justify-end">
             <button
-              className="text-sm font-semibold leading-6 text-gray-900 hover:bg-indigo-500 px-3 py-1 rounded-sm duration-200 ease-out hover:text-white"
+              className="text-sm font-semibold leading-6 text-gray-900 hover:bg-indigo-500 px-3 py-1 rounded-sm duration-200 ease-out hover:text-white dark:text-cyan-100"
               onClick={logout}
             >
               Log out <span aria-hidden="true">&rarr;</span>
             </button>
           </div>
+          {darkMode
+            ?
+            <BsFillSunFill
+              className="ml-8 transform hover:scale-150 cursor-pointer text-xl text-yellow-200 hover:text-yellow-500 transition-all ease-in-out duration-300"
+              onClick={() => setDarkMode(false)}
+            />
+            :
+            <BsFillMoonStarsFill
+              onClick={() => setDarkMode(true)}
+              className="ml-8 transform hover:scale-150 cursor-pointer text-xl text-gray-700 hover:text-gray-800 transition-all ease-in-out duration-300"
+            />
+          }
         </nav>
         <Dialog
           as="div"

--- a/app/src/components/Pricing.jsx
+++ b/app/src/components/Pricing.jsx
@@ -1,25 +1,25 @@
 export default function Example() {
   return (
-    <section className="bg-white">
+    <section className="bg-white dark:bg-slate-900">
       <div className="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-6">
         <div className="mx-auto max-w-screen-md text-center mb-8 lg:mb-12">
-          <h2 className="mb-5 text-4xl md:text-8xl xl:text-4xl text-center font-bold font-heading tracking-px-n leading-none">
+          <h2 className="mb-5 text-4xl md:text-8xl xl:text-4xl text-center font-bold font-heading tracking-px-n leading-none dark:text-cyan-100">
             Pricing that Fits Your Trading Strategy
           </h2>
-          <h5 className="mb-5 text-center tracking-px-n leading-none">
+          <h5 className="mb-5 text-center tracking-px-n leading-none dark:text-cyan-400">
             Take Your Trading to the Next Level with Our Plans
           </h5>
         </div>
         <div className="space-y-8 lg:grid lg:grid-cols-3 sm:gap-6 xl:gap-10 lg:space-y-0">
           {/* Pricing Card */}
-          <div className="flex flex-col p-6 mx-auto max-w-lg text-center bg-white rounded-lg border border-gray-100 dark:border-gray-600 xl:p-8 hover:shadow-2xl hover:scale-105 duration-200 ease-out">
-            <h3 className="mb-4 text-2xl font-semibold">Free</h3>
-            <p className="font-light sm:text-lg">
+          <div className="flex flex-col p-6 mx-auto max-w-lg text-center bg-white rounded-lg border border-gray-100 dark:bg-slate-800 dark:border-gray-600 xl:p-8 hover:shadow-2xl hover:scale-105 duration-200 ease-out">
+            <h3 className="mb-4 text-2xl font-semibold dark:text-white">Free</h3>
+            <p className="font-light sm:text-lg dark:text-cyan-400">
               Get a taste of trading with our free plan.
             </p>
             <div className="flex justify-center items-baseline my-8">
-              <span className="mr-2 text-5xl font-extrabold">$0</span>
-              <span className="text-gray-500 dark:text-gray-400">/month</span>
+              <span className="mr-2 text-5xl font-extrabold dark:text-cyan-300">$0</span>
+              <span className="text-gray-500 dark:text-gray-300">/month</span>
             </div>
             {/* List */}
             <ul role="list" className="mb-8 space-y-4 text-left">
@@ -37,7 +37,7 @@ export default function Example() {
                     clipRule="evenodd"
                   />
                 </svg>
-                <span>
+                <span className="dark:text-cyan-400">
                   Premium support:{" "}
                   <span className="font-semibold">6 months</span>
                 </span>
@@ -56,7 +56,7 @@ export default function Example() {
                     clipRule="evenodd"
                   />
                 </svg>
-                <span>
+                <span className="dark:text-cyan-400">
                   Free updates: <span className="font-semibold">6 months</span>
                 </span>
               </li>
@@ -76,7 +76,7 @@ export default function Example() {
                     stroke-linejoin="round"
                   />
                 </svg>
-                <span>Individual configuration</span>
+                <span className="dark:text-cyan-400">Individual configuration</span>
               </li>
               <li className="flex items-center space-x-3">
                 {/* Icon */}
@@ -94,7 +94,7 @@ export default function Example() {
                     stroke-linejoin="round"
                   />
                 </svg>
-                <span>Individual configuration</span>
+                <span className="dark:text-cyan-400">Individual configuration</span>
               </li>
               <li className="flex items-center space-x-3">
                 {/* Icon */}
@@ -112,7 +112,7 @@ export default function Example() {
                     stroke-linejoin="round"
                   />
                 </svg>
-                <span>Individual configuration</span>
+                <span className="dark:text-cyan-400">Individual configuration</span>
               </li>
             </ul>
             <a
@@ -122,15 +122,16 @@ export default function Example() {
               Get started
             </a>
           </div>
+
           {/* Pricing Card */}
-          <div className="flex flex-col p-6 mx-auto max-w-lg text-center bg-white rounded-lg border border-gray-100 dark:border-gray-600 xl:p-8 hover:shadow-2xl hover:scale-105 duration-200 ease-out">
-            <h3 className="mb-4 text-2xl font-semibold">Professional</h3>
-            <p className="font-light sm:text-lg">
+          <div className="flex flex-col p-6 mx-auto max-w-lg text-center dark:bg-slate-800 bg-white rounded-lg border border-gray-100 dark:border-gray-600 xl:p-8 hover:shadow-2xl hover:scale-105 duration-200 ease-out">
+            <h3 className="mb-4 text-2xl font-semibold dark:text-white">Professional</h3>
+            <p className="font-light sm:text-lg dark:text-cyan-400">
               Unlock advanced trading features with our premium plan.
             </p>
             <div className="flex justify-center items-baseline my-8">
-              <span className="mr-2 text-5xl font-extrabold">$10</span>
-              <span className="text-gray-500 dark:text-gray-400">/month</span>
+              <span className="mr-2 text-5xl font-extrabold dark:text-cyan-300">$10</span>
+              <span className="text-gray-500 dark:text-cyan-300">/month</span>
             </div>
             {/* List */}
             <ul role="list" className="mb-8 space-y-4 text-left">
@@ -148,7 +149,7 @@ export default function Example() {
                     clipRule="evenodd"
                   />
                 </svg>
-                <span>
+                <span className="dark:text-cyan-400">
                   Premium support:{" "}
                   <span className="font-semibold">6 months</span>
                 </span>
@@ -167,7 +168,7 @@ export default function Example() {
                     clipRule="evenodd"
                   />
                 </svg>
-                <span>
+                <span className="dark:text-cyan-400">
                   Free updates: <span className="font-semibold">6 months</span>
                 </span>
               </li>
@@ -187,7 +188,7 @@ export default function Example() {
                     stroke-linejoin="round"
                   />
                 </svg>
-                <span>Individual configuration</span>
+                <span className="dark:text-cyan-400">Individual configuration</span>
               </li>
               <li className="flex items-center space-x-3">
                 {/* Icon */}
@@ -205,7 +206,7 @@ export default function Example() {
                     stroke-linejoin="round"
                   />
                 </svg>
-                <span>Individual configuration</span>
+                <span className="dark:text-cyan-400">Individual configuration</span>
               </li>
               <li className="flex items-center space-x-3">
                 {/* Icon */}
@@ -223,7 +224,7 @@ export default function Example() {
                     stroke-linejoin="round"
                   />
                 </svg>
-                <span>Individual configuration</span>
+                <span className="dark:text-cyan-400">Individual configuration</span>
               </li>
             </ul>
             <a
@@ -233,15 +234,16 @@ export default function Example() {
               Get started
             </a>
           </div>
+
           {/* Pricing Card */}
-          <div className="flex flex-col p-6 mx-auto max-w-lg text-center bg-white rounded-lg border border-gray-100 dark:border-gray-600 xl:p-8 hover:shadow-2xl hover:scale-105 duration-200 ease-out">
-            <h3 className="mb-4 text-2xl font-semibold">Enterprise</h3>
-            <p className="font-light sm:text-lg">
+          <div className="flex flex-col p-6 mx-auto max-w-lg text-center bg-white dark:bg-slate-800 rounded-lg border border-gray-100 dark:border-gray-600 xl:p-8 hover:shadow-2xl hover:scale-105 duration-200 ease-out">
+            <h3 className="mb-4 text-2xl font-semibold dark:text-white">Enterprise</h3>
+            <p className="font-light sm:text-lg dark:text-cyan-400">
               Custom solutions for your trading needs.
             </p>
             <div className="flex justify-center items-baseline my-8">
-              <span className="mr-2 text-5xl font-extrabold">$25</span>
-              <span className="text-gray-500 dark:text-gray-400">/month</span>
+              <span className="mr-2 text-5xl font-extrabold dark:text-cyan-300">$25</span>
+              <span className="text-gray-500 dark:text-cyan-300">/month</span>
             </div>
             {/* List */}
             <ul role="list" className="mb-8 space-y-4 text-left">
@@ -259,7 +261,7 @@ export default function Example() {
                     clipRule="evenodd"
                   />
                 </svg>
-                <span>
+                <span className="dark:text-cyan-400">
                   Premium support:{" "}
                   <span className="font-semibold">6 months</span>
                 </span>
@@ -278,7 +280,7 @@ export default function Example() {
                     clipRule="evenodd"
                   />
                 </svg>
-                <span>
+                <span className="dark:text-cyan-400">
                   Free updates: <span className="font-semibold">6 months</span>
                 </span>
               </li>
@@ -298,7 +300,7 @@ export default function Example() {
                     stroke-linejoin="round"
                   />
                 </svg>
-                <span>Individual configuration</span>
+                <span className="dark:text-cyan-400">Individual configuration</span>
               </li>
               <li className="flex items-center space-x-3">
                 {/* Icon */}
@@ -316,7 +318,7 @@ export default function Example() {
                     stroke-linejoin="round"
                   />
                 </svg>
-                <span>Individual configuration</span>
+                <span className="dark:text-cyan-400">Individual configuration</span>
               </li>
               <li className="flex items-center space-x-3">
                 {/* Icon */}
@@ -334,7 +336,7 @@ export default function Example() {
                     stroke-linejoin="round"
                   />
                 </svg>
-                <span>Individual configuration</span>
+                <span className="dark:text-cyan-400">Individual configuration</span>
               </li>
             </ul>
             <a

--- a/app/src/components/Stats.jsx
+++ b/app/src/components/Stats.jsx
@@ -34,7 +34,7 @@ export default function Example() {
       onEnter={() => setCounterOn(true)}
       onExit={() => setCounterOn(false)}
     >
-      <div className="bg-white py-7 sm:py-35 pb-14">
+      <div className="bg-white py-7 sm:py-35 pb-14 dark:bg-slate-900">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <dl className="grid grid-cols-1 gap-y-16 gap-x-8 text-center lg:grid-cols-3">
             {stats.map((stat) => (
@@ -42,10 +42,10 @@ export default function Example() {
                 key={stat.id}
                 className="mx-auto flex max-w-xs flex-col gap-y-4"
               >
-                <dt className="text-base leading-7 text-gray-600">
+                <dt className="text-base leading-7 text-gray-600 dark:text-cyan-400">
                   {stat.name}
                 </dt>
-                <dd className="order-first text-3xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
+                <dd className="order-first text-3xl font-semibold tracking-tight dark:text-cyan-100 text-gray-900 sm:text-5xl">
                   {stat.suffix}
                   {counterOn && (
                     <CountUp

--- a/app/src/components/Ticker.jsx
+++ b/app/src/components/Ticker.jsx
@@ -1,14 +1,13 @@
 import React, { useEffect, useRef } from 'react';
 
-const Ticker = () => {
+const Ticker = ({ darkMode }) => {
   const widgetContainerRef = useRef(null);
 
   useEffect(() => {
     const script = document.createElement('script');
     script.src = 'https://s3.tradingview.com/external-embedding/embed-widget-ticker-tape.js';
     script.async = true;
-    script.innerHTML = `
-      {
+    script.innerHTML =JSON.stringify({
         "symbols": [
           {
             "proName": "FOREXCOM:SPXUSD",
@@ -32,18 +31,17 @@ const Ticker = () => {
           }
         ],
         "showSymbolLogo": true,
-        "colorTheme": "light",
+        "colorTheme": darkMode ? "dark" : "light",
         "isTransparent": true,
         "displayMode": "adaptive",
         "locale": "in"
-      }
-    `;
+      });
     widgetContainerRef.current.appendChild(script);
 
     return () => {
       widgetContainerRef.current.removeChild(script);
     };
-  }, []);
+  }, [darkMode]);
 
   const tickerContainerStyle = {
     maxWidth: '100%',

--- a/app/src/components/crypto/Header.jsx
+++ b/app/src/components/crypto/Header.jsx
@@ -1,18 +1,18 @@
 export default function Header() {
   return (
-    <div className="bg-white">
+    <div className="bg-white dark:bg-slate-900">
       <div className="relative isolate px-6 pt-20 lg:px-8">
         <div className="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"></div>
         <div className="container mx-auto flex flex-wrap-reverse justify-center">
           <div className="md:w-1/2 max-w-xl w-full flex justify-center items-center my-1.5">
             <div className="md:text-left text-center">
               <h1
-                className="font-extrabold tracking-tight text-gray-900 text-6xl"
+                className="dark:text-cyan-100 font-extrabold tracking-tight text-gray-900 text-6xl"
                 style={{ fontFamily: "'Open Sans Extra Bold', sans-serif" }}
               >
                 Crypto
               </h1>
-              <p className="mt-6 text-lg leading-8 text-gray-600">
+              <p className="mt-6 text-lg leading-8 text-gray-600 dark:text-cyan-400">
                 Decoding the Digital Revolution
               </p>
               <div className="mt-10 flex items-center md:justify-left gap-x-6 w-60 mx-auto md:mx-0">
@@ -24,7 +24,7 @@ export default function Header() {
                 </a>
                 <a
                   href="#"
-                  className="text-sm font-semibold leading-6 text-gray-900"
+                  className="text-sm font-semibold leading-6 text-gray-900 dark:text-cyan-50"
                 >
                   Learn more <span aria-hidden="true">→</span>
                 </a>

--- a/app/src/components/crypto/Widget1.jsx
+++ b/app/src/components/crypto/Widget1.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-const Widget1 = () => {
+const Widget1 = ({ darkMode }) => {
   useEffect(() => {
     const script = document.createElement('script');
     script.src = 'https://s3.tradingview.com/external-embedding/embed-widget-screener.js';
@@ -11,7 +11,7 @@ const Widget1 = () => {
       defaultColumn: 'overview',
       screener_type: 'crypto_mkt',
       displayCurrency: 'USD',
-      colorTheme: 'light',
+      colorTheme: `${darkMode ? 'dark' : 'light'}`,
       locale: 'in',
     });
 
@@ -25,7 +25,7 @@ const Widget1 = () => {
         widgetContainer.innerHTML = '';
       }
     };
-  }, []);
+  }, [darkMode]);
 
   return (
     <div className="tradingview-widget-container" style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>

--- a/app/src/components/news/CryptoWidget.jsx
+++ b/app/src/components/news/CryptoWidget.jsx
@@ -1,30 +1,28 @@
 import React, { useEffect, useRef } from 'react';
 
-const CryptoWidget = () => {
+const CryptoWidget = ({ darkMode }) => {
   const widgetContainerRef = useRef(null);
 
   useEffect(() => {
     const script = document.createElement('script');
     script.src = 'https://s3.tradingview.com/external-embedding/embed-widget-timeline.js';
     script.async = true;
-    script.innerHTML = `
-      {
+    script.innerHTML = JSON.stringify({
         "feedMode": "market",
-        "colorTheme": "light",
+        "colorTheme": `${darkMode ? 'dark' : 'light'}`,
         "isTransparent": false,
         "displayMode": "adaptive",
         "width": "1000",
         "height": "400",
         "locale": "in",
         "market": "crypto"
-      }
-    `;
+      });
     widgetContainerRef.current.appendChild(script);
 
     return () => {
       widgetContainerRef.current.removeChild(script);
     };
-  }, []);
+  }, [darkMode]);
 
   return (
     <div className="tradingview-widget-container" style={containerStyle}>

--- a/app/src/components/news/Header.jsx
+++ b/app/src/components/news/Header.jsx
@@ -1,18 +1,18 @@
 export default function Header() {
   return (
-    <div className="bg-white">
+    <div className="bg-white dark:bg-slate-900">
       <div className="relative isolate px-6 pt-20 lg:px-8">
         <div className="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"></div>
         <div className="container mx-auto flex flex-wrap-reverse justify-center">
           <div className="md:w-1/2 max-w-xl w-full flex justify-center items-center my-1.5">
             <div className="md:text-left text-center">
               <h1
-                className="font-extrabold tracking-tight text-gray-900 text-6xl"
+                className="font-extrabold tracking-tight dark:text-cyan-100 text-gray-900 text-6xl"
                 style={{ fontFamily: "'Open Sans Extra Bold', sans-serif" }}
               >
                 News
               </h1>
-              <p className="mt-6 text-lg leading-8 text-gray-600">
+              <p className="mt-6 text-lg leading-8 text-gray-600 dark:text-cyan-400">
                 Stay Ahead, Trade Smart
               </p>
               <div className="mt-10 flex items-center md:justify-left gap-x-6 w-60 mx-auto md:mx-0">
@@ -24,7 +24,7 @@ export default function Header() {
                 </a>
                 <a
                   href="#"
-                  className="text-sm font-semibold leading-6 text-gray-900"
+                  className="text-sm font-semibold leading-6 text-gray-900 dark:text-cyan-50"
                 >
                   Learn more <span aria-hidden="true">→</span>
                 </a>

--- a/app/src/components/news/StocksWidget.jsx
+++ b/app/src/components/news/StocksWidget.jsx
@@ -1,24 +1,22 @@
 import React, { useEffect, useRef } from 'react';
 
-const StocksWidget = () => {
+const StocksWidget = ({ darkMode }) => {
   const widgetContainerRef = useRef(null);
 
   useEffect(() => {
     const script = document.createElement('script');
     script.src = 'https://s3.tradingview.com/external-embedding/embed-widget-timeline.js';
     script.async = true;
-    script.innerHTML = `
-      {
+    script.innerHTML = JSON.stringify({
         "feedMode": "market",
-        "colorTheme": "light",
+        "colorTheme": darkMode ? 'dark' : 'light',
         "isTransparent": false,
         "displayMode": "adaptive",
         "width": "1000",
         "height": "400",
         "locale": "in",
         "market": "stock"
-      }
-    `;
+      });
     widgetContainerRef.current.appendChild(script);
 
     return () => {

--- a/app/src/components/stocks/Header.jsx
+++ b/app/src/components/stocks/Header.jsx
@@ -1,18 +1,18 @@
 export default function Header() {
   return (
-    <div className="bg-white">
+    <div className="bg-white dark:bg-slate-900">
       <div className="relative isolate px-6 pt-20 lg:px-8">
         <div className="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"></div>
         <div className="container mx-auto flex flex-wrap-reverse justify-center">
           <div className="md:w-1/2 max-w-xl w-full flex justify-center items-center my-1.5">
             <div className="md:text-left text-center">
               <h1
-                className="font-extrabold tracking-tight text-gray-900 text-6xl"
+                className="font-extrabold tracking-tight text-gray-900 dark:text-cyan-100 text-6xl"
                 style={{ fontFamily: "'Open Sans Extra Bold', sans-serif" }}
               >
                 Stocks
               </h1>
-              <p className="mt-6 text-lg leading-8 text-gray-600">
+              <p className="mt-6 text-lg leading-8 text-gray-600 dark:text-cyan-400">
                 Unveiling Market Dynamics
               </p>
               <div className="mt-10 flex items-center md:justify-left gap-x-6 w-60 mx-auto md:mx-0">
@@ -24,7 +24,7 @@ export default function Header() {
                 </a>
                 <a
                   href="#"
-                  className="text-sm font-semibold leading-6 text-gray-900"
+                  className="text-sm font-semibold leading-6 text-gray-900 dark:text-cyan-50"
                 >
                   Learn more <span aria-hidden="true">→</span>
                 </a>

--- a/app/src/components/stocks/Widget1.jsx
+++ b/app/src/components/stocks/Widget1.jsx
@@ -1,17 +1,17 @@
 import React, { useEffect } from 'react';
 
-const Widget1 = () => {
+const Widget1 = ({ darkMode }) => {
   useEffect(() => {
     const script = document.createElement('script');
     script.src = 'https://s3.tradingview.com/external-embedding/embed-widget-market-quotes.js';
     script.async = true;
-    script.innerHTML = `{
-      "title": "Stocks",
-      "width": 1000,
-      "height": 800,
-      "locale": "in",
-      "showSymbolLogo": true,
-      "symbolsGroups": [
+    script.innerHTML = JSON.stringify({
+      title: "Stocks",
+      width: 1000,
+      height: 800,
+      locale: "in",
+      showSymbolLogo: true,
+      symbolsGroups: [
         {
           "name": "Financial",
           "symbols": [
@@ -96,12 +96,12 @@ const Widget1 = () => {
           ]
         }
       ],
-      "colorTheme": "light"
-    }`;
+      colorTheme: `${darkMode ? 'dark' : 'light'}`,
+    });
 
     const widgetContainer = document.createElement('div');
     widgetContainer.className = 'tradingview-widget-container';
-   
+
 
     widgetContainer.appendChild(script);
 
@@ -115,7 +115,7 @@ const Widget1 = () => {
         container.innerHTML = '';
       }
     };
-  }, []);
+  }, [darkMode]);
 
   return (
     <div className="tradingview-widget-container" style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>

--- a/app/src/components/trade/CryptoWidget.jsx
+++ b/app/src/components/trade/CryptoWidget.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 
 let tvScriptLoadingPromise;
 
-export default function CryptoWidget() {
+export default function CryptoWidget({ darkMode }) {
   const onLoadScriptRef = useRef();
 
   useEffect(
@@ -33,7 +33,7 @@ export default function CryptoWidget() {
             symbol: "BINANCE:BTCUSDT",
             interval: "D",
             timezone: "Etc/UTC",
-            theme: "light",
+            theme: darkMode ? "dark" : "light",
             style: "1",
             locale: "in",
             toolbar_bg: "#f1f3f6",
@@ -44,7 +44,7 @@ export default function CryptoWidget() {
         }
       }
     },
-    []
+    [darkMode]
   );
 
   return (

--- a/app/src/components/trade/Header.jsx
+++ b/app/src/components/trade/Header.jsx
@@ -1,18 +1,18 @@
 export default function Header() {
   return (
-    <div className="bg-white">
+    <div className="bg-white dark:bg-slate-900">
       <div className="relative isolate px-6 pt-20 lg:px-8">
         <div className="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"></div>
         <div className="container mx-auto flex flex-wrap-reverse justify-center">
           <div className="md:w-1/2 max-w-xl w-full flex justify-center items-center my-1.5">
             <div className="md:text-left text-center">
               <h1
-                className="font-extrabold tracking-tight text-gray-900 text-6xl"
+                className="font-extrabold tracking-tight text-gray-900 dark:text-cyan-100 text-6xl"
                 style={{ fontFamily: "'Open Sans Extra Bold', sans-serif" }}
               >
                 Trade
               </h1>
-              <p className="mt-6 text-lg leading-8 text-gray-600">
+              <p className="mt-6 text-lg leading-8 text-gray-600 dark:text-cyan-400">
                 Navigating the Trading World
               </p>
               <div className="mt-10 flex items-center md:justify-left gap-x-6 w-60 mx-auto md:mx-0">
@@ -24,7 +24,7 @@ export default function Header() {
                 </a>
                 <a
                   href="#"
-                  className="text-sm font-semibold leading-6 text-gray-900"
+                  className="text-sm font-semibold leading-6 text-gray-900 dark:text-cyan-50"
                 >
                   Learn more <span aria-hidden="true">→</span>
                 </a>

--- a/app/src/components/trade/StocksWidget.jsx
+++ b/app/src/components/trade/StocksWidget.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 
 let tvScriptLoadingPromise;
 
-export default function StocksWidget() {
+export default function StocksWidget({ darkMode }) {
   const onLoadScriptRef = useRef();
 
   useEffect(
@@ -33,7 +33,7 @@ export default function StocksWidget() {
             symbol: "NASDAQ:AAPL",
             interval: "D",
             timezone: "Etc/UTC",
-            theme: "light",
+            theme: darkMode ? "dark" : "light",
             style: "1",
             locale: "in",
             toolbar_bg: "#f1f3f6",
@@ -44,7 +44,7 @@ export default function StocksWidget() {
         }
       }
     },
-    []
+    [darkMode]
   );
 
   return (

--- a/app/src/firebase/auth.js
+++ b/app/src/firebase/auth.js
@@ -2,20 +2,12 @@ import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 
 const firebaseConfig = {
-	// apiKey: import.meta.env.VITE_API_KEY,
-	// authDomain: import.meta.env.VITE_AUTH_DOMAIN,
-	// projectId: import.meta.env.VITE_PROJECT_ID,
-	// storageBucket: import.meta.env.VITE_STORAGE_BUCKET,
-	// messagingSenderId: import.meta.env.VITE_MESSAGING_SENDER_ID,
-	// appId: import.meta.env.VITE_APP_ID,
-
-	apiKey: "AIzaSyCaEnLB9i1AjNkoR3jj0BhoKJ4TZWDikzI",
-	authDomain: "animating-buttons-5ae2b.firebaseapp.com",
-	projectId: "animating-buttons-5ae2b",
-	storageBucket: "animating-buttons-5ae2b.appspot.com",
-	messagingSenderId: "328113147529",
-	appId: "1:328113147529:web:517d447a8a83f581ee0058",
-	measurementId: "G-WHKWF2ZSFD"
+	apiKey: import.meta.env.VITE_API_KEY,
+	authDomain: import.meta.env.VITE_AUTH_DOMAIN,
+	projectId: import.meta.env.VITE_PROJECT_ID,
+	storageBucket: import.meta.env.VITE_STORAGE_BUCKET,
+	messagingSenderId: import.meta.env.VITE_MESSAGING_SENDER_ID,
+	appId: import.meta.env.VITE_APP_ID,
 };
 
 // Initialize Firebase

--- a/app/src/firebase/auth.js
+++ b/app/src/firebase/auth.js
@@ -2,12 +2,20 @@ import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 
 const firebaseConfig = {
-	apiKey: import.meta.env.VITE_API_KEY,
-	authDomain: import.meta.env.VITE_AUTH_DOMAIN,
-	projectId: import.meta.env.VITE_PROJECT_ID,
-	storageBucket: import.meta.env.VITE_STORAGE_BUCKET,
-	messagingSenderId: import.meta.env.VITE_MESSAGING_SENDER_ID,
-	appId: import.meta.env.VITE_APP_ID,
+	// apiKey: import.meta.env.VITE_API_KEY,
+	// authDomain: import.meta.env.VITE_AUTH_DOMAIN,
+	// projectId: import.meta.env.VITE_PROJECT_ID,
+	// storageBucket: import.meta.env.VITE_STORAGE_BUCKET,
+	// messagingSenderId: import.meta.env.VITE_MESSAGING_SENDER_ID,
+	// appId: import.meta.env.VITE_APP_ID,
+
+	apiKey: "AIzaSyCaEnLB9i1AjNkoR3jj0BhoKJ4TZWDikzI",
+	authDomain: "animating-buttons-5ae2b.firebaseapp.com",
+	projectId: "animating-buttons-5ae2b",
+	storageBucket: "animating-buttons-5ae2b.appspot.com",
+	messagingSenderId: "328113147529",
+	appId: "1:328113147529:web:517d447a8a83f581ee0058",
+	measurementId: "G-WHKWF2ZSFD"
 };
 
 // Initialize Firebase

--- a/app/src/pages/Cryptocurrencies.jsx
+++ b/app/src/pages/Cryptocurrencies.jsx
@@ -1,12 +1,12 @@
 import Widget1 from "../components/crypto/Widget1";
 import Header from "../components/crypto/Header";
 
-const Cryptocurrencies = () => {
+const Cryptocurrencies = ({ darkMode }) => {
   return (
-    <div>
+    <div className="dark:bg-slate-900">
       <Header />
       <br />
-      <Widget1 />
+      <Widget1 darkMode={darkMode} />
       <br />
     </div>
   );

--- a/app/src/pages/Dashboard.jsx
+++ b/app/src/pages/Dashboard.jsx
@@ -1,9 +1,9 @@
 
 const Dashboard = () => {
   return (
-    <div>
-      <h1 className="text-5xl text-center p-8 m-8">Dashboard</h1>
-      <p>
+    <div className="dark:bg-slate-900 flex justify-center flex-col items-center">
+      <h1 className="text-5xl p-14 m-8 dark:text-cyan-100 ">Dashboard</h1>
+      <p className="dark:text-cyan-100 text-center w-[1100px]">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Cupiditate,
         placeat blanditiis, est non atque cum aut ratione pariatur quas eligendi
         iure earum illo quos aspernatur beatae nesciunt expedita. Quidem nam ad

--- a/app/src/pages/Derivatives.jsx
+++ b/app/src/pages/Derivatives.jsx
@@ -2,9 +2,9 @@
 
 const Derivatives = () => {
   return (
-    <div>
-      <h1 className="text-5xl text-center p-8 m-8">Derivatives</h1>
-      <p>
+    <div className="dark:bg-slate-900 flex justify-center flex-col items-center">
+      <h1 className="text-5xl text-center p-14 m-8  dark:text-cyan-100 ">Derivatives</h1>
+      <p className="dark:text-cyan-100 text-center w-[1100px]">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Cupiditate,
         placeat blanditiis, est non atque cum aut ratione pariatur quas eligendi
         iure earum illo quos aspernatur beatae nesciunt expedita. Quidem nam ad

--- a/app/src/pages/Homepage.jsx
+++ b/app/src/pages/Homepage.jsx
@@ -6,11 +6,11 @@ import Accordion from "../components/Accordion";
 import Pricing from "../components/Pricing";
 import Ticker from "../components/Ticker";
 
-const Homepage = ({ props }) => {
+const Homepage = ({ darkMode }) => {
   return (
     <div className="dark:bg-slate-900">
       <Header />
-      <Ticker />
+      <Ticker darkMode={darkMode} />
       <Stats />
       <Features />
       <Pricing />

--- a/app/src/pages/Homepage.jsx
+++ b/app/src/pages/Homepage.jsx
@@ -8,7 +8,7 @@ import Ticker from "../components/Ticker";
 
 const Homepage = ({ props }) => {
   return (
-    <div>
+    <div className="dark:bg-slate-900">
       <Header />
       <Ticker />
       <Stats />

--- a/app/src/pages/Institutional.jsx
+++ b/app/src/pages/Institutional.jsx
@@ -1,9 +1,9 @@
 
 const Institutional = () => {
   return (
-    <div>
-      <h1 className="text-5xl text-center p-8 m-8">Institutional</h1>
-      <p>
+    <div className="dark:bg-slate-900 flex justify-center flex-col items-center">
+      <h1 className="text-5xl text-center p-14 m-8  dark:text-cyan-100 ">Institutional</h1>
+      <p className="dark:text-cyan-100 text-center w-[1100px]">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Cupiditate,
         placeat blanditiis, est non atque cum aut ratione pariatur quas eligendi
         iure earum illo quos aspernatur beatae nesciunt expedita. Quidem nam ad

--- a/app/src/pages/Login.jsx
+++ b/app/src/pages/Login.jsx
@@ -44,39 +44,39 @@ const Login = () => {
   };
 
   return (
-    <div className="mt-16 flex">
+    <div className="mt-16 m-10 flex">
       {/* Login Form */}
       <form className="md:w-1/2 flex flex-col items-start p-4 px-6 mx-auto gap-6 text-lg">
-        <h2 className="mx-auto text-2xl md:text-3xl font-bold">
+        <h2 className="mx-auto text-2xl md:text-3xl font-bold dark:text-cyan-100">
           Login to our platform
         </h2>
         <div className="text-red-600"> {error && <p>{error}</p>}</div>
         <div className="w-full flex flex-col items-start gap-2">
-          <label htmlFor="email">Your Email</label>
+          <label htmlFor="email" className="dark:text-cyan-300">Your Email</label>
           <input
             type="email"
             name="email"
             value={user.email}
             onChange={handleChange}
             placeholder="name@company.com"
-            className="w-[100%] bg-slate-100 py-2 px-4 focus:outline-indigo-500"
+            className="w-[100%] bg-slate-100 py-2 px-4 focus:outline-indigo-500 dark:bg-slate-700 dark:text-cyan-50"
           />
         </div>
         <div className="w-full flex flex-col items-start gap-2">
-          <label htmlFor="pass">Your Password</label>
+          <label htmlFor="pass" className="dark:text-cyan-300">Your Password</label>
           <input
             type="password"
             name="pass"
             value={user.pass}
             onChange={handleChange}
             placeholder="*********"
-            className="w-[100%] bg-slate-100 py-2 px-4 focus:outline-indigo-500"
+            className="w-[100%] bg-slate-100 py-2 px-4 focus:outline-indigo-500 dark:bg-slate-700 dark:text-cyan-50"
           />
         </div>
         <div className="w-full flex flex-row justify-between items-center">
           <div className="flex flex-row justify-between items-center">
             <input type="checkbox" name="checkbox" className="h-4 w-4" />
-            <label className="px-2" htmlFor="checkbox">
+            <label className="px-2 dark:text-cyan-400" htmlFor="checkbox">
               {" "}
               Remember Me
             </label>
@@ -96,7 +96,7 @@ const Login = () => {
           Login to your account
         </button>
         <div className="mx-auto">
-          <p>
+          <p className="dark:text-cyan-400">
             Not Registered?{" "}
             <Link
               to="/SignUp"

--- a/app/src/pages/NFT.jsx
+++ b/app/src/pages/NFT.jsx
@@ -2,9 +2,9 @@
 
 const NFT = () => {
   return (
-    <div>
-      <h1 className="text-5xl text-center p-8 m-8">NFT</h1>
-      <p>
+    <div className="dark:bg-slate-900 flex justify-center flex-col items-center">
+      <h1 className="text-5xl text-center p-14 m-8 dark:text-cyan-100">NFT</h1>
+      <p className="dark:text-cyan-100 text-center w-[1100px]">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Cupiditate,
         placeat blanditiis, est non atque cum aut ratione pariatur quas eligendi
         iure earum illo quos aspernatur beatae nesciunt expedita. Quidem nam ad

--- a/app/src/pages/News.jsx
+++ b/app/src/pages/News.jsx
@@ -2,14 +2,14 @@ import CryptoWidget from "../components/news/CryptoWidget";
 import Header from "../components/news/Header";
 import StocksWidget from "../components/news/StocksWidget";
 
-const News = () => {
+const News = ({ darkMode }) => {
   return (
     <div>
       <Header />
       <br/>
-      <CryptoWidget />
+      <CryptoWidget darkMode={darkMode} />
       <br/>
-      <StocksWidget />
+      <StocksWidget darkMode={darkMode} />
       <br/>
     </div>
   );

--- a/app/src/pages/SignUp.jsx
+++ b/app/src/pages/SignUp.jsx
@@ -57,77 +57,77 @@ const SignUp = () => {
   };
 
   return (
-    <div className="flex">
+    <div className="flex mt-16 m-10">
       <div className="my-auto hidden md:block md:w-1/2">
         <img src={signupIMG} alt="" />
       </div>
 
       {/* Signup Form */}
       <form className="md:w-1/2 flex flex-col items-start p-4 px-6 mx-auto gap-6 text-lg">
-        <h2 className="mx-auto text-2xl md:text-3xl font-bold">
+        <h2 className="mx-auto text-2xl md:text-3xl font-bold dark:text-cyan-100">
           Signup to our platform
         </h2>
         <div className="text-red-600"> {error && <p>{error}</p>}</div>
         <div className="w-full flex flex-row items-center justify-between gap-8">
           <div className="flex flex-col items-start gap-2">
-            <label htmlFor="fName">First Name</label>
+            <label htmlFor="fName" className="dark:text-cyan-300">First Name</label>
             <input
               type="text"
               name="fName"
               value={user.fName}
               onChange={handleChange}
               placeholder="Jhon"
-              className="w-[100%] bg-slate-100 py-2 px-4 focus:outline-indigo-500"
+              className="w-[100%] bg-slate-100 py-2 px-4 focus:outline-indigo-500  dark:bg-slate-700 dark:text-cyan-50"
             />
           </div>
           <div className="flex flex-col items-start gap-2">
-            <label htmlFor="lName">Last Name</label>
+            <label htmlFor="lName" className="dark:text-cyan-300">Last Name</label>
             <input
               type="text"
               name="lName"
               value={user.lName}
               onChange={handleChange}
               placeholder="Doe"
-              className="w-[100%] bg-slate-100 py-2 px-4 focus:outline-indigo-500"
+              className="w-[100%] bg-slate-100 py-2 px-4 focus:outline-indigo-500  dark:bg-slate-700 dark:text-cyan-50"
             />
           </div>
         </div>
         <div className="w-full flex flex-col items-start gap-2">
-          <label htmlFor="userName">Username</label>
+          <label htmlFor="userName" className="dark:text-cyan-300">Username</label>
           <input
             type="text"
             name="userName"
             value={user.userName}
             onChange={handleChange}
             placeholder="jhon007"
-            className="w-[100%] bg-slate-100 py-2 px-4 focus:outline-indigo-500"
+            className="w-[100%] bg-slate-100 py-2 px-4 focus:outline-indigo-500  dark:bg-slate-700 dark:text-cyan-50"
           />
         </div>
         <div className="w-full flex flex-col items-start gap-2">
-          <label htmlFor="email">Your Email</label>
+          <label htmlFor="email" className="dark:text-cyan-300">Your Email</label>
           <input
             type="email"
             name="email"
             value={user.email}
             onChange={handleChange}
             placeholder="jhon@xyz.com"
-            className="w-[100%] bg-slate-100 py-2 px-4 focus:outline-indigo-500"
+            className="w-[100%] bg-slate-100 py-2 px-4 focus:outline-indigo-500  dark:bg-slate-700 dark:text-cyan-50"
           />
         </div>
         <div className="w-full flex flex-row items-center justify-between gap-8">
           <div className="flex flex-col items-start gap-2">
-            <label htmlFor="pass">Create Password</label>
+            <label htmlFor="pass" className="dark:text-cyan-300">Create Password</label>
             <input
               type="password"
               name="pass"
               value={user.pass}
               onChange={handleChange}
               placeholder="********"
-              className="w-[100%] bg-slate-100 py-2 px-4 focus:outline-indigo-500"
+              className="w-[100%] bg-slate-100 py-2 px-4 focus:outline-indigo-500  dark:bg-slate-700 dark:text-cyan-50"
             />
           </div>
           <div className="flex flex-col items-start gap-2">
-            <label htmlFor="confirmPass">Confirm Password</label>
+            <label htmlFor="confirmPass" className="dark:text-cyan-300">Confirm Password</label>
             <input
               type="password"
               name="confirmPass"
@@ -136,8 +136,8 @@ const SignUp = () => {
               placeholder="********"
               className={
                 !user.confirmPass.length == 0 && user.confirmPass === user.pass
-                  ? "w-[100%] bg-slate-100 py-2 px-4 focus:outline-green-500"
-                  : "w-[100%] bg-slate-100 py-2 px-4 focus:outline-red-500"
+                  ? "w-[100%] bg-slate-100 py-2 px-4 focus:outline-green-500  dark:bg-slate-700 dark:text-cyan-50"
+                  : "w-[100%] bg-slate-100 py-2 px-4 focus:outline-red-500  dark:bg-slate-700 dark:text-cyan-50"
               }
             />
           </div>
@@ -149,7 +149,7 @@ const SignUp = () => {
           Signup to our platform
         </button>
         <div className="mx-auto">
-          <p>
+          <p className="dark:text-cyan-400">
             Already have an account?{" "}
             <Link
               to="/Login"

--- a/app/src/pages/Stocks.jsx
+++ b/app/src/pages/Stocks.jsx
@@ -1,11 +1,11 @@
 import Widget1 from "../components/stocks/Widget1";
 import Header from "../components/stocks/Header";
 
-const Stocks = () => {
+const Stocks = ({ darkMode }) => {
   return (
     <div>
       <Header />
-      <Widget1 />
+      <Widget1 darkMode={darkMode} />
       <br/>
     </div>
   );

--- a/app/src/pages/Support.jsx
+++ b/app/src/pages/Support.jsx
@@ -1,9 +1,9 @@
 
 const Support = () => {
   return (
-    <div>
-      <h1 className="text-5xl text-center p-8 m-8">Support</h1>
-      <p>
+    <div className="dark:bg-slate-900 flex justify-center flex-col items-center">
+      <h1 className="text-5xl text-center p-14 m-8  dark:text-cyan-100 ">Support</h1>
+      <p className="dark:text-cyan-100 text-center w-[1100px]">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Cupiditate,
         placeat blanditiis, est non atque cum aut ratione pariatur quas eligendi
         iure earum illo quos aspernatur beatae nesciunt expedita. Quidem nam ad

--- a/app/src/pages/Trade.jsx
+++ b/app/src/pages/Trade.jsx
@@ -2,14 +2,14 @@ import Header from "../components/trade/Header";
 import StocksWidget from "../components/trade/StocksWidget";
 import CryptoWidget from "../components/trade/CryptoWidget";
 
-const Trade = () => {
+const Trade = ({ darkMode }) => {
   return (
     <div>
       <Header />
       <br />
-      <CryptoWidget />
+      <CryptoWidget darkMode={darkMode} />
       <br />
-      <StocksWidget />
+      <StocksWidget darkMode={darkMode} />
       <br />
     </div>
   );

--- a/app/tailwind.config.cjs
+++ b/app/tailwind.config.cjs
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: "class",
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Closes: #92 

## Changes

- Add: dark mode for the desktop view.
- changed styles and code according to changes made
- Used slate-900 as primary bg color for dark mode 

## Screenshots

- Navbar
<img width="960" alt="image" src="https://github.com/Stoccoin-Official/Stoccoin-Website/assets/47839626/e003d30c-b885-4824-aa25-d9407de6e2a4">

- Homepage
<img width="960" alt="image" src="https://github.com/Stoccoin-Official/Stoccoin-Website/assets/47839626/1e77f21a-1597-4028-8c36-d691d059cba2">
<img width="960" alt="image" src="https://github.com/Stoccoin-Official/Stoccoin-Website/assets/47839626/7383edfb-1b34-4b2f-9e93-3d65d24e7425">
<img width="960" alt="image" src="https://github.com/Stoccoin-Official/Stoccoin-Website/assets/47839626/43225f2a-aac3-4e30-bf8c-9eaa20f2da09">
<img width="960" alt="image" src="https://github.com/Stoccoin-Official/Stoccoin-Website/assets/47839626/fdfbab85-4338-42b3-ae91-2b2104178140">
<img width="960" alt="image" src="https://github.com/Stoccoin-Official/Stoccoin-Website/assets/47839626/ac6a8623-0028-48b5-ab66-3a65189281b4">
<img width="960" alt="image" src="https://github.com/Stoccoin-Official/Stoccoin-Website/assets/47839626/9ca60f38-3c40-40d5-98a6-e2397854a708">

- DashBoard
<img width="960" alt="image" src="https://github.com/Stoccoin-Official/Stoccoin-Website/assets/47839626/b0c3ca61-f0e5-4164-a1a3-3053efb8bf5e">

- Footer
<img width="960" alt="image" src="https://github.com/Stoccoin-Official/Stoccoin-Website/assets/47839626/beb56b17-f50e-4f6e-83f2-1153a4a837f9">


PS: I would like to add dark mode for the responsive site in a different issue. as of now this is for the desktop site.
Above screenshots are examples.